### PR TITLE
Fixes ITC-562

### DIFF
--- a/style.css
+++ b/style.css
@@ -2101,12 +2101,12 @@ h5.home_date {
         box-shadow: 1px 1px 1px Gray;
     }
 
-    .nav-collapse .dropdown-menu.open.twocolumn {
+    .nav-collapse .dropdown-menu.twocolumn {
         width: 482px;
         left: -80px;
     }
     
-    .nav-collapse .dropdown-menu.open.threecolumn {
+    .nav-collapse .dropdown-menu.threecolumn {
         width: 723px;
         left: -160px;
     }


### PR DESCRIPTION
Javascript calculates if the dropdown should go to the left or right based on the position and width of the dropdown relative to the edge of the menu bar. In the css the change in width for a two or three column layout are only added to the dropdown once it is opened after the javascript has calculated the direction the drop down should go in causing the issue. The issue is fixed by adjusting the width of a two/three column dropdown before it is opened. 
