### PR TITLE
Last modified date no longer appears on sitemap page.

### DIFF
--- a/style.css
+++ b/style.css
@@ -864,6 +864,10 @@ h5.date {
     margin: 10px 0 0;
 }
 
+#post-395 #last-modified-date {
+    display: none;
+}
+
 #tertiary {
     padding: 48px 0px 0px 10px;
     background: white;


### PR DESCRIPTION
css fix. currently targets sitemap post specifically to leave "Last Modified Date" styling open for other pages. if sitemap post is somehow changed (possibly through reimplementation or such), the css will need to be modified again.
